### PR TITLE
[BUG] The pin #7 should be inside list comprehension.

### DIFF
--- a/pingo/examples/parts/7seg_demo.py
+++ b/pingo/examples/parts/7seg_demo.py
@@ -7,7 +7,7 @@ INTERVAL = 0.3
 
 ard = detect.MyBoard()
 
-display_pins = [ard.pins[i] for i in range(8, 14)] + [7]
+display_pins = [ard.pins[i] for i in range(8, 14) + [7]]
 
 for pin in display_pins:
     pin.mode = OUT


### PR DESCRIPTION
After code refactoring, the pin number related to the DP segment was left outside the list comprehension call, adding the **integer 7** instead of the **pin ard.pin[7]** object. This bug was not affecting the example because DP (pin 7) was not being used.
