### PR TITLE
Pingo Part Servo

### DIFF
--- a/pingo/parts/__init__.py
+++ b/pingo/parts/__init__.py
@@ -1,2 +1,3 @@
 from .led import Led  # noqa
 from .button import Switch  # noqa
+from .servo import Servo  # noqa

--- a/pingo/parts/servo.py
+++ b/pingo/parts/servo.py
@@ -1,0 +1,19 @@
+import pingo
+from pingo.boared import ArgumentOutOfRange
+
+
+class Servo(object):
+
+    def __init__(self, pin, start_position=90):
+        pin.mode = pingo.PWM
+        pin.frequency = 50
+        self.pin = pin
+        self.move(start_position)
+
+    def move(self, position):
+        if not 0 <= position <= 180:
+            raise ArgumentOutOfRange()
+        self.pin.value = float(position) * (12.5 - 2.5) / (180.0) + 2.5
+
+
+

--- a/pingo/parts/servo.py
+++ b/pingo/parts/servo.py
@@ -1,5 +1,5 @@
 import pingo
-from pingo.boared import ArgumentOutOfRange
+from pingo.board import ArgumentOutOfRange
 
 
 class Servo(object):

--- a/pingo/parts/servo.py
+++ b/pingo/parts/servo.py
@@ -4,16 +4,19 @@ from pingo.board import ArgumentOutOfRange
 
 class Servo(object):
 
-    def __init__(self, pin, start_position=90):
+    def __init__(self, pin):
         pin.mode = pingo.PWM
         pin.frequency = 50
         self.pin = pin
-        self.move(start_position)
+        # Percent of dutycycle that represents zero
+        # Default: 2.5% ~ 0.5ms pulse @ 50Hz
+        self._botton_end = 2.5
+        # Percent of dutycycle that represents 180
+        # Default: 12.5% ~ 2.5ms pulse @ 50Hz
+        self._top_end = 12.5
 
     def move(self, position):
         if not 0 <= position <= 180:
             raise ArgumentOutOfRange()
-        self.pin.value = float(position) * (12.5 - 2.5) / (180.0) + 2.5
-
-
-
+        pmin, pmax = self._botton_end, self._top_end
+        self.pin.value = float(position) * (pmax - pmin) / (180.0) + pmin


### PR DESCRIPTION
I have coded the technic on #53 as a pingo.part

I tested on RaspberryPi. It work, no need for a 5V signal, the 3.3 signal will do.
Although, the servo must be feed with a 5V source.

Two different 9g Analog servos were tested.
The Turnigy's servo worked with the default values.
The generic servo worked after some calibration on Servo._botton_end  and Servo._top_end
