### PR TITLE
add verbose option

### DIFF
--- a/pingo/arduino/firmata.py
+++ b/pingo/arduino/firmata.py
@@ -25,6 +25,8 @@ PIN_MODES = {
     pingo.OUT: 1,
 }
 
+VERBOSE = False
+
 
 def get_arduino():
     serial_port = detect._find_arduino_dev(platform.system())
@@ -44,7 +46,7 @@ class ArduinoFirmata(Board, AnalogInputCapable):
 
         super(ArduinoFirmata, self).__init__()
         self.port = port
-        self.PyMata = PyMata(self.port)
+        self.PyMata = PyMata(self.port, verbose=VERBOSE)
 
         detected_digital_pins = len(self.PyMata._command_handler.digital_response_table)
         detected_analog_pins = len(self.PyMata._command_handler.analog_response_table)


### PR DESCRIPTION
Verbose is by default on in pyMata. From my point of view 50 % of the information are not really helpful.

```bash
$ python blink_firmata_auto.py 

Python Version 2.7.8 (default, Apr 15 2015, 09:26:43) 
[GCC 4.9.2 20150212 (Red Hat 4.9.2-6)]

PyMata version 2.06  Copyright(C) 2013-15 Alan Yorinks    All rights reserved.

Opening Arduino Serial port /dev/ttyACM0 

Please wait while Arduino is being detected. This can take up to 30 seconds ...
Board initialized in 0 seconds
Total Number of Pins Detected = 20
Total Number of Analog Pins Detected = 6
```