### PR TITLE
README example code uses pingo.detect.MyBoard() but it has changed to get_board()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Once you have a board instance, it's possible to access its pins through the ``b
     import pingo
     from time import sleep
 
-    board = pingo.detect.MyBoard()
+    board = pingo.detect.get_board()
     led_pin = board.pins[13]
     led_pin.mode = pingo.OUT
 


### PR DESCRIPTION
Had a small problem running the test from the README.rst. After a little inspecting I discovered the problem in pingo.detect.MyBoard() which changed to pingo.detect.get_board() but not in the README.