### PR TITLE
DetectionFailed raised when arduino is not found

### DIFF
--- a/pingo/detect/detect.py
+++ b/pingo/detect/detect.py
@@ -54,9 +54,7 @@ def get_board():
             if device:
                 return pingo.arduino.ArduinoFirmata(device)
 
-        print('Using GhostBoard...')
-        # TODO decide which board return
-        return pingo.ghost.GhostBoard()
+        raise DetectionFailed()
 
     elif machine == 'i586':
         # TODO: assume it's a Galileo2


### PR DESCRIPTION
This change was done to avoid any problem when using arduino.
If for any cause the board can't be detected, and the GhostBoard is returned it can introduce an possible fail point into the client app.
Raising the DetectionFailed exception prevents an unexpected behavior of pingo.detect.get_board function.
