### PR TITLE
Stop blinking shouldn't always switch off led

### DIFF
--- a/pingo/parts/led.py
+++ b/pingo/parts/led.py
@@ -123,6 +123,7 @@ class BlinkTask(object):
         :param off_delay: delay while LED is off
         """
         self.led = led
+        self.led_pin_state_initial = self.led.pin.state
         self.active = True
         self.forever = times == 0
         self.times_remaining = times
@@ -143,7 +144,7 @@ class BlinkTask(object):
             else:
                 time.sleep(self.off_delay)
         else:
-            self.led.off()
+            self.led.pin.state = self.led_pin_state_initial
             self.active = False
 
 


### PR DESCRIPTION
It should fix https://github.com/pingo-io/pingo-py/issues/104

When led was on and user asks led to blink 3 times (for example), after blinking led shouldn't be switched off but should fallback to initial state (before blinking)